### PR TITLE
Fix LaTeX Typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,12 @@ We use a monte carlo sampler to make duels where each of the 2 selected prompts 
 
 In each duel, both prompts answer each of the test cases and a separate prompt evaluates which answer was the best. The ELO scores of the prompts are then updated according to the following formulas:
 
-$$\mu_{A}' = \mu_{A} + \frac{K}{N} \cdot (score - expected\_score(A,B))$$
-$$\mu_{B}' = \mu_{B} + \frac{K}{N} \cdot (1 - score - expected\_score(B,A))$$
+$$\mu_{A}' = \mu_{A} + \frac{K}{N} \cdot (score - expected\\\_score(A,B))$$
+
+$$\mu_{B}' = \mu_{B} + \frac{K}{N} \cdot (1 - score - expected\\\_score(B,A))$$
+
 $$\sigma_{A}' = \sigma_{A} \cdot LR$$
+
 $$\sigma_{B}' = \sigma_{B} \cdot LR$$
 
 **Where:**
@@ -102,8 +105,8 @@ $$\sigma_{B}' = \sigma_{B} \cdot LR$$
     - If two prompts with the same $\mu$ battle and one prompt wins all of the rounds it will gain $\dfrac{K}{2}$ points and the other will lose $\dfrac{K}{2}$ points.
 
 - $score$ is $1$ if $A$ wins and $0$ if $B$ wins,
-- $expected\_score(A,B)$ is the expected chance of $A$ winning of $B$ given their normal distributions. This is calculated by the following formula:
-$$expected\_score(A,B) = \frac{1}{1 + 10^{\frac{\mu_{B} - \mu_{A}}{400}}}$$
+- $expected\\\_score(A,B)$ is the expected chance of $A$ winning of $B$ given their normal distributions. This is calculated by the following formula:
+$$expected\\\_score(A,B) = \frac{1}{1 + 10^{\frac{\mu_{B} - \mu_{A}}{400}}}$$
 
 The reason why we update the $\sigma$ of each prompt is that we have more certainty on the distribution after each match, thus it should have a smaller standard deviation.
 


### PR DESCRIPTION
There were a couple of issues in the LaTeX sections of the README:

- Underscores were not properly escaped. This is actually GitHub's fault, but basically you have to escape underscores twice, meaning you escape `_ -> \_`, and then escape again: `\_ -> \\\_`.
- One line break between LaTeX blocks is insufficient. You need two; there were 3 missing equations are are now visible.

As SDEs, we must Insist on the Highest Standards and be Customer Obsessed, so these changes should be rolled out ASAP.